### PR TITLE
Refactor CsvChat struct to reorder fields for consistency

### DIFF
--- a/youtube/src/infrastructure/filesystem/chat_repository/csv_struct.rs
+++ b/youtube/src/infrastructure/filesystem/chat_repository/csv_struct.rs
@@ -7,8 +7,8 @@ use std::fs::File;
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CsvChat {
     pub id: String,
-    pub posted_at: String,
     pub author_external_channel_id: String,
+    pub posted_at: String,
     pub author_name: String,
     pub message: String,
     pub is_moderator: bool,


### PR DESCRIPTION
- Moved the `posted_at` field to follow `author_external_channel_id` in the CsvChat struct, enhancing the organization of chat data fields.