### PR TITLE
Update GitHub Actions workflow badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![GitHub Release](https://img.shields.io/github/v/release/toshiki670/yt-tool)
-![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/toshiki670/yt-tool/rust_check.yml)
+![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/toshiki670/yt-tool/rust.yml)
 
 # yt tool
 


### PR DESCRIPTION
- Change workflow status badge to point to the correct workflow file
- Ensure accurate representation of CI/CD status in project README