### PR TITLE
Refactor live chat conversion to use async processing

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,12 +17,19 @@ jobs:
       TZ: Asia/Tokyo
     steps:
       - uses: actions/checkout@v4
+      - name: Check format
+        run: cargo fmt --check
+
+  lint:
+    runs-on: ubuntu-latest
+    env:
+      TZ: Asia/Tokyo
+    steps:
+      - uses: actions/checkout@v4
       - name: Cache cargo registry
         uses: Swatinem/rust-cache@v2
       - name: Prepare clippy
         run: rustup component add clippy
-      - name: Check format
-        run: cargo fmt --check
       - name: Check lint
         run: cargo clippy --all-targets --all-features -- -D warnings
 

--- a/support/src/glob.rs
+++ b/support/src/glob.rs
@@ -22,8 +22,7 @@ pub fn expend_glob_input_patterns(patterns: &[String]) -> anyhow::Result<Vec<Pat
     let results = paths_array
         .into_iter()
         // Convert iterator Paths to an array
-        .map(|p| p.collect::<Vec<Result<PathBuf, glob::GlobError>>>())
-        .flatten()
+        .flat_map(|p| p.collect::<Vec<Result<PathBuf, glob::GlobError>>>())
         .map(|p| p.map_err(|e| anyhow::anyhow!(e)))
         .collect();
 

--- a/support/src/glob.rs
+++ b/support/src/glob.rs
@@ -23,12 +23,7 @@ pub fn expend_glob_input_patterns(patterns: &[String]) -> anyhow::Result<Vec<Pat
         .into_iter()
         // Convert iterator Paths to an array
         .map(|p| p.collect::<Vec<Result<PathBuf, glob::GlobError>>>())
-        // Fold arrays into a single array
-        .fold(vec![], |mut acc, g| {
-            acc.extend(g);
-            acc
-        })
-        .into_iter()
+        .flatten()
         .map(|p| p.map_err(|e| anyhow::anyhow!(e)))
         .collect();
 

--- a/youtube/src/domain/chat_service.rs
+++ b/youtube/src/domain/chat_service.rs
@@ -16,6 +16,12 @@ use super::{
     simple_chat::{PostedAtValue, SimpleChatEntity},
 };
 
+impl LiveChatEntity {
+    pub async fn try_into_simple_chats(self) -> anyhow::Result<Vec<SimpleChatEntity>> {
+        self.try_into()
+    }
+}
+
 impl TryInto<Vec<SimpleChatEntity>> for LiveChatEntity {
     type Error = anyhow::Error;
 


### PR DESCRIPTION
- Add async method `try_into_simple_chats` to `LiveChatEntity`
- Modify `convert_from_lines` to use async processing with `future::join_all`
- Utilize `collect_results` to handle conversion errors
- Improve error context for line-specific conversion failures