### PR TITLE
Add tests for glob pattern expansion functionality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -786,6 +786,8 @@ dependencies = [
  "anyhow",
  "futures",
  "glob",
+ "pretty_assertions",
+ "tempfile",
  "thiserror",
  "tokio",
 ]

--- a/support/Cargo.toml
+++ b/support/Cargo.toml
@@ -18,3 +18,7 @@ futures = { workspace = true }
 glob = { workspace = true }
 anyhow = { workspace = true }
 thiserror = { workspace = true }
+
+[dev-dependencies]
+pretty_assertions = "1.4.1"
+tempfile = "3.16.0"


### PR DESCRIPTION
- Implement comprehensive test cases for expend_glob_input_patterns and expend_glob_pattern
- Cover scenarios including successful file matching and handling of no input files
- Use tempfile and tokio for creating temporary test directories and async file operations