### PR TITLE
v0.3.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -958,7 +958,7 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "support"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "futures",
@@ -1317,7 +1317,7 @@ dependencies = [
 
 [[package]]
 name = "youtube"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1338,7 +1338,7 @@ dependencies = [
 
 [[package]]
 name = "yt-tool"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,5 +43,5 @@ tokio = { version = "1.43.0", features = ["full"] }
 url = "2.5.4"
 
 [workspace.package]
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ## Install from GitHub Releases
 
 ```
-cargo install --git https://github.com/toshiki670/yt-tool.git --tag v0.3.1
+cargo install --git https://github.com/toshiki670/yt-tool.git --tag v0.3.2
 ```
 
 ## Install from local


### PR DESCRIPTION
- Update version in Cargo.lock, Cargo.toml, and README.md
- Update GitHub installation command to use v0.3.2 tag