### PR TITLE
Refactor-old-code

### DIFF
--- a/src/cli/youtube/chat.rs
+++ b/src/cli/youtube/chat.rs
@@ -50,12 +50,12 @@ impl Route for Args {
                 .context("Chat watching process failed")?;
         } else if let Some(patterns) = &self.input_patterns {
             let input_files = glob::expend_glob_input_patterns(patterns)?;
-            let interface = LiveChatJsonInterface::new(&input_files);
+            let command = LiveChatJsonCommand::new(&input_files);
 
             if self.rename_with_timestamp {
-                interface.generate_files_with_timestamped_name().await?;
+                command.generate_files_with_timestamped_name().await?;
             } else {
-                interface.generate_files_with_csv().await?;
+                command.generate_files_with_csv().await?;
             }
         } else {
             anyhow::bail!("Either input patterns or a file to watch must be specified.");

--- a/youtube/src/application.rs
+++ b/youtube/src/application.rs
@@ -1,6 +1,5 @@
 //! This module contains the application layer logic.
 //! The application layer manages business logic and coordinates between the domain and infrastructure layers.
 
-pub(crate) mod chat_service;
 pub(crate) mod ports;
 pub(crate) mod use_cases;

--- a/youtube/src/application/use_cases.rs
+++ b/youtube/src/application/use_cases.rs
@@ -1,1 +1,2 @@
+pub mod chat_convert;
 pub mod watch_chat;

--- a/youtube/src/application/use_cases/chat_convert.rs
+++ b/youtube/src/application/use_cases/chat_convert.rs
@@ -2,11 +2,11 @@ use crate::domain::repositories::ChatServiceRepository;
 use futures::future;
 use rust_support::anyhow::collect_results;
 
-pub struct ChatConvertService<T: ChatServiceRepository> {
+pub struct ChatConvertUseCase<T: ChatServiceRepository> {
     chat_service_repositories: Vec<T>,
 }
 
-impl<T: ChatServiceRepository> ChatConvertService<T> {
+impl<T: ChatServiceRepository> ChatConvertUseCase<T> {
     pub fn new(chat_service_repositories: Vec<T>) -> Self {
         Self {
             chat_service_repositories,
@@ -18,7 +18,7 @@ impl<T: ChatServiceRepository> ChatConvertService<T> {
     }
 }
 
-impl<T> ChatConvertService<T>
+impl<T> ChatConvertUseCase<T>
 where
     T: ChatServiceRepository,
 {

--- a/youtube/src/interface.rs
+++ b/youtube/src/interface.rs
@@ -2,6 +2,4 @@
 //! The interface layer is the layer that interacts with the outside world.
 
 pub mod cli;
-pub mod formatted_json_interface;
-pub mod live_chat_json_interface;
 pub mod presenter;

--- a/youtube/src/interface/cli.rs
+++ b/youtube/src/interface/cli.rs
@@ -1,3 +1,7 @@
-mod watch_chat_command;
+pub mod formatted_json_command;
+pub mod live_chat_json_command;
+pub mod watch_chat_command;
 
+pub use formatted_json_command::FormattedJsonCommand;
+pub use live_chat_json_command::LiveChatJsonCommand;
 pub use watch_chat_command::WatchChatCommand;

--- a/youtube/src/interface/cli/formatted_json_command.rs
+++ b/youtube/src/interface/cli/formatted_json_command.rs
@@ -1,4 +1,4 @@
-use crate::application::chat_service::ChatConvertService;
+use crate::application::use_cases::chat_convert::ChatConvertUseCase;
 use crate::infrastructure::io::chat_service_repository::IoChatServiceRepository;
 use std::path::{Path, PathBuf};
 
@@ -32,7 +32,7 @@ impl FormattedJsonCommand<'_, PathBuf> {
             target_path,
         )?];
 
-        let service = ChatConvertService::new(repositories);
+        let service = ChatConvertUseCase::new(repositories);
 
         service.convert_from_chunk().await
     }
@@ -51,7 +51,7 @@ impl FormattedJsonCommand<'_, PathBuf> {
             target_path,
         )?];
 
-        let service = ChatConvertService::new(repositories);
+        let service = ChatConvertUseCase::new(repositories);
         service.convert_from_chunk().await
     }
 
@@ -64,7 +64,7 @@ impl FormattedJsonCommand<'_, PathBuf> {
 
         let repositories = vec![IoChatServiceRepository::file_to_in_memory(source_path)?];
 
-        let service = ChatConvertService::new(repositories);
+        let service = ChatConvertUseCase::new(repositories);
         service.convert_from_chunk().await?;
 
         let repositories = service.move_chat_service_repository();
@@ -93,7 +93,7 @@ impl FormattedJsonCommand<'_, Vec<PathBuf>> {
 
         let repositories = rust_support::anyhow::collect_results(results)?;
 
-        let service = ChatConvertService::new(repositories);
+        let service = ChatConvertUseCase::new(repositories);
 
         service.convert_from_chunk().await
     }
@@ -114,7 +114,7 @@ impl FormattedJsonCommand<'_, String> {
             target_path,
         )?];
 
-        let service = ChatConvertService::new(repositories);
+        let service = ChatConvertUseCase::new(repositories);
 
         service.convert_from_chunk().await
     }
@@ -130,7 +130,7 @@ impl FormattedJsonCommand<'_, String> {
             source_string,
         )?];
 
-        let service = ChatConvertService::new(repositories);
+        let service = ChatConvertUseCase::new(repositories);
         service.convert_from_chunk().await?;
 
         let repositories = service.move_chat_service_repository();

--- a/youtube/src/interface/cli/live_chat_json_command.rs
+++ b/youtube/src/interface/cli/live_chat_json_command.rs
@@ -1,4 +1,4 @@
-use crate::application::chat_service::ChatConvertService;
+use crate::application::use_cases::chat_convert::ChatConvertUseCase;
 use crate::infrastructure::io::chat_service_repository::IoChatServiceRepository;
 use chrono::prelude::*;
 use std::path::{Path, PathBuf};
@@ -33,7 +33,7 @@ impl LiveChatJsonCommand<'_, PathBuf> {
             target_path,
         )?];
 
-        let service = ChatConvertService::new(repositories);
+        let service = ChatConvertUseCase::new(repositories);
 
         service.convert_from_lines().await
     }
@@ -53,7 +53,7 @@ impl LiveChatJsonCommand<'_, PathBuf> {
             target_path,
         )?];
 
-        let service = ChatConvertService::new(repositories);
+        let service = ChatConvertUseCase::new(repositories);
 
         service.convert_from_lines().await
     }
@@ -78,7 +78,7 @@ impl LiveChatJsonCommand<'_, Vec<PathBuf>> {
 
         let repositories = rust_support::anyhow::collect_results(results)?;
 
-        let service = ChatConvertService::new(repositories);
+        let service = ChatConvertUseCase::new(repositories);
 
         service.convert_from_lines().await
     }
@@ -104,7 +104,7 @@ impl LiveChatJsonCommand<'_, Vec<PathBuf>> {
 
         let repositories = rust_support::anyhow::collect_results(results)?;
 
-        let service = ChatConvertService::new(repositories);
+        let service = ChatConvertUseCase::new(repositories);
 
         service.convert_from_lines().await
     }
@@ -125,7 +125,7 @@ impl LiveChatJsonCommand<'_, String> {
             target_path,
         )?];
 
-        let service = ChatConvertService::new(repositories);
+        let service = ChatConvertUseCase::new(repositories);
 
         service.convert_from_lines().await
     }

--- a/youtube/src/lib.rs
+++ b/youtube/src/lib.rs
@@ -6,8 +6,8 @@ mod interface;
 pub mod prelude {
     //! This module contains the prelude for the library.
 
+    pub use crate::interface::cli::FormattedJsonCommand;
+    pub use crate::interface::cli::LiveChatJsonCommand;
     pub use crate::interface::cli::WatchChatCommand;
-    pub use crate::interface::formatted_json_interface::*;
-    pub use crate::interface::live_chat_json_interface::*;
     pub use crate::interface::presenter::StdoutPresenter;
 }

--- a/youtube/tests/formatted_json_service/file.rs
+++ b/youtube/tests/formatted_json_service/file.rs
@@ -9,7 +9,7 @@ use std::{
 };
 use tempfile::tempdir;
 use tokio::fs;
-use youtube::prelude::FormattedJsonInterface;
+use youtube::prelude::FormattedJsonCommand;
 
 fn test_root_dir() -> PathBuf {
     env::current_dir()
@@ -38,8 +38,8 @@ async fn it_generate_with_paths() -> anyhow::Result<()> {
     let imput_paths = read_paths(test_dir.path())?;
 
     // Run the test subject
-    let interface = FormattedJsonInterface::new(&imput_paths);
-    interface.generate_files_with_csv().await?;
+    let command = FormattedJsonCommand::new(&imput_paths);
+    command.generate_files_with_csv().await?;
 
     // Prepare expected file paths
     let expected_dir = test_expected_dir();
@@ -70,8 +70,8 @@ async fn it_generate_with_type() -> anyhow::Result<()> {
     let output_type = "csv".to_string();
 
     // Run the test subject
-    let interface = FormattedJsonInterface::new(&input_path);
-    interface.generate_file_with_type(&output_type).await?;
+    let command = FormattedJsonCommand::new(&input_path);
+    command.generate_file_with_type(&output_type).await?;
 
     // Assert the result
     let expected_path = test_expected_dir().join("formatted.csv");

--- a/youtube/tests/formatted_json_service/string.rs
+++ b/youtube/tests/formatted_json_service/string.rs
@@ -5,7 +5,7 @@ use pretty_assertions::assert_eq;
 use std::{env, path::PathBuf};
 use tempfile::tempdir;
 use tokio::{fs, try_join};
-use youtube::prelude::FormattedJsonInterface;
+use youtube::prelude::FormattedJsonCommand;
 
 fn test_root_dir() -> PathBuf {
     env::current_dir()
@@ -25,8 +25,8 @@ async fn it_generate_with_path() -> anyhow::Result<()> {
     let output_path = test_dir.path().join("output.csv");
 
     // Run the test subject
-    let interface = FormattedJsonInterface::new(&input_json);
-    interface.generate_file_with_path(&output_path).await?;
+    let command = FormattedJsonCommand::new(&input_json);
+    command.generate_file_with_path(&output_path).await?;
 
     // Read expected csv file
     let expected_path = test_expected_dir().join("formatted.csv");

--- a/youtube/tests/live_chat_json_service/file.rs
+++ b/youtube/tests/live_chat_json_service/file.rs
@@ -11,7 +11,7 @@ use std::{
 };
 use tempfile::tempdir;
 use tokio::fs;
-use youtube::prelude::LiveChatJsonInterface;
+use youtube::prelude::LiveChatJsonCommand;
 
 fn test_root_dir() -> PathBuf {
     env::current_dir()
@@ -73,8 +73,8 @@ async fn it_generate_with_path_and_timestamped_name() -> anyhow::Result<()> {
     let imput_paths = vec![imput_path];
 
     // Run the test subject
-    let interface = LiveChatJsonInterface::new(&imput_paths);
-    interface.generate_files_with_timestamped_name().await?;
+    let command = LiveChatJsonCommand::new(&imput_paths);
+    command.generate_files_with_timestamped_name().await?;
 
     // Prepare expected file paths
     let imput_path = imput_paths.first().unwrap();
@@ -108,8 +108,8 @@ async fn it_generate_with_type() -> anyhow::Result<()> {
     let output_type = "csv".to_string();
 
     // Run the test subject
-    let interface = LiveChatJsonInterface::new(&input_path);
-    interface.generate_file_with_type(&output_type).await?;
+    let command = LiveChatJsonCommand::new(&input_path);
+    command.generate_file_with_type(&output_type).await?;
 
     // Assert the result
     let expected_path = test_expected_dir().join("live_chat.csv");

--- a/youtube/tests/live_chat_json_service/string.rs
+++ b/youtube/tests/live_chat_json_service/string.rs
@@ -4,7 +4,7 @@ use pretty_assertions::assert_eq;
 use std::{env, path::PathBuf};
 use tempfile::tempdir;
 use tokio::{fs, try_join};
-use youtube::prelude::LiveChatJsonInterface;
+use youtube::prelude::LiveChatJsonCommand;
 
 fn test_root_dir() -> PathBuf {
     env::current_dir()
@@ -24,8 +24,8 @@ async fn it_generate_with_path() -> anyhow::Result<()> {
     let output_path = test_dir.path().join("output.csv");
 
     // Run the test subject
-    let interface = LiveChatJsonInterface::new(&input_json);
-    interface.generate_file_with_string(&output_path).await?;
+    let command = LiveChatJsonCommand::new(&input_json);
+    command.generate_file_with_string(&output_path).await?;
 
     // Read expected csv file
     let expected_path = test_expected_dir().join("live_chat.csv");


### PR DESCRIPTION
- Removed the deprecated chat_service module and replaced it with the new ChatConvertUseCase in the application layer.
- Updated CLI commands to utilize ChatConvertUseCase for chat conversion operations.
- Added chat_convert module to encapsulate chat conversion logic and improve code organization.