### PR TITLE
Add sccache installation and configuration

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustc-wrapper = "sccache"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -85,6 +85,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
-          components: sccache
+      - name: Install sccache
+        run: cargo install sccache
       - name: Run tests
         run: cargo test --workspace --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -85,5 +85,6 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
+          components: sccache
       - name: Run tests
         run: cargo test --workspace --verbose

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -16,6 +16,7 @@ cargo install cargo-llvm-cov
 cargo install cargo-outdated
 cargo install cargo-release
 cargo install cargo-watch
+cargo install sccache
 '''
 ]
 


### PR DESCRIPTION
- Added `sccache` to the installation commands in Makefile.toml.
- Created a new .cargo/config.toml file to set `rustc-wrapper` to `sccache` for build optimization.